### PR TITLE
added effects for Either and Maybe

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "test": "pulp test"
   },
   "devDependencies": {
+    "bower": "^1.8.2",
     "pulp": "^11.0.0",
     "purescript": "^0.11.3",
     "purescript-psa": "^0.5.0"

--- a/src/Run/Either.purs
+++ b/src/Run/Either.purs
@@ -1,0 +1,40 @@
+module Run.Either
+( liftEither
+, left
+, right
+, runEither
+, _either
+, EITHER  
+) where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Functor.Variant (FProxy, SProxy(..))
+import Run (Run, lift, on, send)
+import Run as Run
+
+type EITHER e = FProxy (Either e)
+
+_either :: SProxy "either"
+_either = SProxy
+
+liftEither :: forall e a r. Either e a -> Run(either :: EITHER e | r) a
+liftEither = lift _either
+
+right :: forall e a r. a -> Run(either :: EITHER e | r) a
+right = (lift _either) <<< Right
+
+left :: forall e a r. e -> Run(either :: EITHER e | r) a
+left = (lift _either) <<< Left
+
+runEither :: forall e a r. Run (either :: EITHER e | r) a -> Run r (Either e a)
+runEither = loop
+  where
+  handle = on _either Left Right
+  loop r = case Run.peel r of
+    Left a -> case handle a of
+      Left (Left e)   -> pure $ Left e 
+      Left (Right a') -> loop a'
+      Right a'        -> send a' >>= runEither
+    Right a -> pure $ Right a

--- a/src/Run/Either.purs
+++ b/src/Run/Either.purs
@@ -19,16 +19,16 @@ type EITHER e = FProxy (Either e)
 _either :: SProxy "either"
 _either = SProxy
 
-liftEither :: forall e a r. Either e a -> Run(either :: EITHER e | r) a
+liftEither :: ∀ e a r. Either e a -> Run(either :: EITHER e | r) a
 liftEither = lift _either
 
-right :: forall e a r. a -> Run(either :: EITHER e | r) a
+right :: ∀ e a r. a -> Run(either :: EITHER e | r) a
 right = (lift _either) <<< Right
 
-left :: forall e a r. e -> Run(either :: EITHER e | r) a
+left :: ∀ e a r. e -> Run(either :: EITHER e | r) a
 left = (lift _either) <<< Left
 
-runEither :: forall e a r. Run (either :: EITHER e | r) a -> Run r (Either e a)
+runEither :: ∀ e a r. Run (either :: EITHER e | r) a -> Run r (Either e a)
 runEither = loop
   where
   handle = on _either Left Right

--- a/src/Run/Maybe.purs
+++ b/src/Run/Maybe.purs
@@ -1,4 +1,11 @@
-module Run.Maybe where
+module Run.Maybe
+( liftMaybe
+, just
+, nothing
+, runMaybe
+, _maybe
+, MAYBE  
+) where
 
 import Prelude
 
@@ -16,13 +23,19 @@ _maybe = SProxy
 liftMaybe :: forall a r. Maybe a -> Run(maybe :: MAYBE | r) a
 liftMaybe = lift _maybe 
 
+just :: forall a r. a -> Run(maybe :: MAYBE | r) a
+just = (lift _maybe) <<< Just
+
+nothing :: forall a r. Run(maybe :: MAYBE | r) a
+nothing = lift _maybe Nothing
+
 runMaybe :: forall a r. Run (maybe :: MAYBE | r) a -> Run r (Maybe a)
 runMaybe = loop
   where
   handle = on _maybe Left Right
   loop r = case Run.peel r of
     Left a -> case handle a of
-      Left Nothing -> pure Nothing
-      Left (Just b) -> loop b
-      Right a' -> send a' >>= runMaybe
+      Left Nothing    -> pure Nothing
+      Left (Just a')  -> loop a' 
+      Right a'        -> send a' >>= runMaybe
     Right a -> pure $ Just a

--- a/src/Run/Maybe.purs
+++ b/src/Run/Maybe.purs
@@ -20,16 +20,16 @@ type MAYBE = FProxy Maybe
 _maybe :: SProxy "maybe"
 _maybe = SProxy
 
-liftMaybe :: forall a r. Maybe a -> Run(maybe :: MAYBE | r) a
+liftMaybe :: ∀ a r. Maybe a -> Run(maybe :: MAYBE | r) a
 liftMaybe = lift _maybe 
 
-just :: forall a r. a -> Run(maybe :: MAYBE | r) a
+just :: ∀ a r. a -> Run(maybe :: MAYBE | r) a
 just = (lift _maybe) <<< Just
 
-nothing :: forall a r. Run(maybe :: MAYBE | r) a
+nothing :: ∀ a r. Run(maybe :: MAYBE | r) a
 nothing = lift _maybe Nothing
 
-runMaybe :: forall a r. Run (maybe :: MAYBE | r) a -> Run r (Maybe a)
+runMaybe :: ∀ a r. Run (maybe :: MAYBE | r) a -> Run r (Maybe a)
 runMaybe = loop
   where
   handle = on _maybe Left Right

--- a/src/Run/Maybe.purs
+++ b/src/Run/Maybe.purs
@@ -8,33 +8,21 @@ import Data.Maybe (Maybe(..))
 import Run (Run, lift, on, send)
 import Run as Run
 
-
-data MaybeEffect a
-  = JustEffect a
-  | NothingEffect
-derive instance maybeEffectInstance :: Functor MaybeEffect
-
-type MAYBE = FProxy MaybeEffect
+type MAYBE = FProxy Maybe
 
 _maybe :: SProxy "maybe"
 _maybe = SProxy
 
 liftMaybe :: forall a r. Maybe a -> Run(maybe :: MAYBE | r) a
-liftMaybe (Just a) = lift _maybe (JustEffect a)
-liftMaybe Nothing = lift _maybe NothingEffect
+liftMaybe = lift _maybe 
 
-handleMaybe :: forall a r. MaybeEffect a -> (Run r (Maybe a))
-handleMaybe (JustEffect a) = pure $ Just a
-handleMaybe NothingEffect  = pure Nothing 
-
--- runPure :: forall r1 r2 a. (VariantF r1 (Run r1 a) -> Step (Run r1 a) (VariantF r2 (Run r1 a))) -> Run r1 a -> Run r2 a
 runMaybe :: forall a r. Run (maybe :: MAYBE | r) a -> Run r (Maybe a)
 runMaybe = loop
   where
-    handle = on _maybe Left Right
-    loop r = case Run.peel r of
-      Left a -> case handle a of
-        Left NothingEffect -> pure Nothing
-        Left (JustEffect b) -> loop b
-        Right a' -> send a' >>= runMaybe
-      Right a -> pure $ Just a
+  handle = on _maybe Left Right
+  loop r = case Run.peel r of
+    Left a -> case handle a of
+      Left Nothing -> pure Nothing
+      Left (Just b) -> loop b
+      Right a' -> send a' >>= runMaybe
+    Right a -> pure $ Just a

--- a/src/Run/Maybe.purs
+++ b/src/Run/Maybe.purs
@@ -1,0 +1,40 @@
+module Run.Maybe where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Functor.Variant (FProxy, SProxy(..))
+import Data.Maybe (Maybe(..))
+import Run (Run, lift, on, send)
+import Run as Run
+
+
+data MaybeEffect a
+  = JustEffect a
+  | NothingEffect
+derive instance maybeEffectInstance :: Functor MaybeEffect
+
+type MAYBE = FProxy MaybeEffect
+
+_maybe :: SProxy "maybe"
+_maybe = SProxy
+
+liftMaybe :: forall a r. Maybe a -> Run(maybe :: MAYBE | r) a
+liftMaybe (Just a) = lift _maybe (JustEffect a)
+liftMaybe Nothing = lift _maybe NothingEffect
+
+handleMaybe :: forall a r. MaybeEffect a -> (Run r (Maybe a))
+handleMaybe (JustEffect a) = pure $ Just a
+handleMaybe NothingEffect  = pure Nothing 
+
+-- runPure :: forall r1 r2 a. (VariantF r1 (Run r1 a) -> Step (Run r1 a) (VariantF r2 (Run r1 a))) -> Run r1 a -> Run r2 a
+runMaybe :: forall a r. Run (maybe :: MAYBE | r) a -> Run r (Maybe a)
+runMaybe = loop
+  where
+    handle = on _maybe Left Right
+    loop r = case Run.peel r of
+      Left a -> case handle a of
+        Left NothingEffect -> pure Nothing
+        Left (JustEffect b) -> loop b
+        Right a' -> send a' >>= runMaybe
+      Right a -> pure $ Just a

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -77,19 +77,19 @@ chooseProgram = do
   liftEff $ log $ show n
   pure (n + 1)
 
-maybeEitherProgram :: forall eff r. Run(maybe :: MAYBE, either :: (EITHER String), eff ∷ EFF (console ∷ CONSOLE | eff) | r) Unit 
+maybeEitherProgram :: ∀ eff r. Run(maybe :: MAYBE, either :: (EITHER String), eff ∷ EFF (console ∷ CONSOLE | eff) | r) Unit 
 maybeEitherProgram = do
   i1 <- liftMaybe (Just 10)
   i2 <- liftEither (Right 20)
   liftEff $ (log $ "A MAYBE, EITHER and EFF program will log 30 (I hope): " <> (show (i1 + i2)))
 
-rightNothingProgram :: forall eff r. Run(maybe :: MAYBE, either :: (EITHER String), eff ∷ EFF (console ∷ CONSOLE | eff) | r) Unit 
+rightNothingProgram :: ∀ eff r. Run(maybe :: MAYBE, either :: (EITHER String), eff ∷ EFF (console ∷ CONSOLE | eff) | r) Unit 
 rightNothingProgram = do
   i1 <- right 20
   i2 <- nothing
   liftEff $ (log $ "This shoud never be seen!!!" <> (show (i1 + i2)))
 
-justLeftProgram :: forall eff r. Run(maybe :: MAYBE, either :: (EITHER String), eff ∷ EFF (console ∷ CONSOLE | eff) | r) Unit 
+justLeftProgram :: ∀ eff r. Run(maybe :: MAYBE, either :: (EITHER String), eff ∷ EFF (console ∷ CONSOLE | eff) | r) Unit 
 justLeftProgram = do
   i2 <- just 10
   i1 <- left "OMG ERROR!"


### PR DESCRIPTION
Hi Nate, I love this library! I've used the equivalent in Scala and while it's nice to get the benefits that Free/Freer monads offer, it pales in comparison to this lib! 

As discussed on Slack, I've added effects for Maybe and Either, which makes `do` blocks quite a bit more clean. Example:

```
maybeEitherProgram :: ∀ eff r. Run(maybe :: MAYBE, either :: (EITHER String), eff ∷ EFF (console ∷ CONSOLE | eff) | r) Unit
maybeEitherProgram = do
  i1 <- liftMaybe (Just 10)
  i2 <- liftEither (Right 20)
  liftEff $ (log $ "A MAYBE, EITHER and EFF program will log 30 (I hope): " <> (show (i1 + i2)))
```