### PR TITLE
Unlabeled alternates

### DIFF
--- a/src/Run/Except.purs
+++ b/src/Run/Except.purs
@@ -4,20 +4,30 @@ module Run.Except
   , FAIL
   , _except
   , liftExcept
+  , liftExceptAt
   , runExcept
+  , runExceptAt
   , runFail
+  , runFailAt
   , throw
+  , throwAt
   , fail
+  , failAt
   , rethrow
+  , rethrowAt
   , note
+  , noteAt
   , fromJust
+  , fromJustAt
   , catch
+  , catchAt
   ) where
 
 import Prelude
 
 import Data.Either (Either(..), either)
 import Data.Maybe (Maybe(..), maybe')
+import Data.Symbol (class IsSymbol)
 import Run (Run, SProxy(..), FProxy)
 import Run as Run
 
@@ -33,48 +43,130 @@ _except ∷ SProxy "except"
 _except = SProxy
 
 liftExcept ∷ ∀ e a r. Except e a → Run (except ∷ EXCEPT e | r) a
-liftExcept = Run.lift _except
+liftExcept = liftExceptAt _except
+
+liftExceptAt
+  ∷ ∀ t e a r s
+  . IsSymbol s
+  ⇒ RowCons s (EXCEPT e) t r
+  ⇒ SProxy s
+  → Except e a
+  → Run r a
+liftExceptAt = Run.lift
 
 throw ∷ ∀ e a r. e → Run (except ∷ EXCEPT e | r) a
-throw = liftExcept <<< Except
+throw = throwAt _except
+
+throwAt
+  ∷ ∀ t e a r s
+  . IsSymbol s
+  ⇒ RowCons s (EXCEPT e) t r
+  ⇒ SProxy s
+  → e
+  → Run r a
+throwAt sym = liftExceptAt sym <<< Except
 
 fail ∷ ∀ a r. Run (except ∷ FAIL | r) a
-fail = throw unit
+fail = failAt _except
+
+failAt ∷
+  ∀ t a r s
+  . IsSymbol s
+  ⇒ RowCons s FAIL t r
+  ⇒ SProxy s
+  → Run r a
+failAt sym = throwAt sym unit
 
 rethrow ∷ ∀ e a r. Either e a → Run (except ∷ EXCEPT e | r) a
-rethrow = either throw pure
+rethrow = rethrowAt _except
+
+rethrowAt ∷
+  ∀ t e a r s
+  . IsSymbol s
+  ⇒ RowCons s (EXCEPT e) t r
+  ⇒ SProxy s
+  → Either e a
+  → Run r a
+rethrowAt sym = either (throwAt sym) pure
 
 note ∷ ∀ e a r. e → Maybe a → Run (except ∷ EXCEPT e | r) a
-note e = maybe' (\_ → throw e) pure
+note = noteAt _except
+
+noteAt ∷
+  ∀ t e a r s
+  . IsSymbol s
+  ⇒ RowCons s (EXCEPT e) t r
+  ⇒ SProxy s
+  → e
+  → Maybe a
+  → Run r a
+noteAt sym e = maybe' (\_ → throwAt sym e) pure
 
 fromJust ∷ ∀ a r. Maybe a → Run (except ∷ FAIL | r) a
-fromJust = note unit
+fromJust = fromJustAt _except
+
+fromJustAt ∷
+  ∀ t a r s
+  . IsSymbol s
+  ⇒ RowCons s FAIL t r
+  ⇒ SProxy s
+  → Maybe a
+  → Run r a
+fromJustAt sym = noteAt sym unit
 
 catch ∷ ∀ e a r. (e → Run r a) → Run (except ∷ EXCEPT e | r) a → Run r a
-catch = loop
+catch = catchAt _except
+
+catchAt ∷
+  ∀ t e a r s
+  . IsSymbol s
+  ⇒ RowCons s (EXCEPT e) t r
+  ⇒ SProxy s
+  → (e → Run t a)
+  → Run r a
+  → Run t a
+catchAt sym = loop
   where
-  handle = Run.on _except Left Right
+  handle = Run.on sym Left Right
   loop k r = case Run.peel r of
     Left a → case handle a of
       Left (Except e) →
         k e
       Right a' →
-        Run.send a' >>= catch k
+        Run.send a' >>= catchAt sym k
     Right a →
       pure a
 
 runExcept ∷ ∀ e a r. Run (except ∷ EXCEPT e | r) a → Run r (Either e a)
-runExcept = loop
+runExcept = runExceptAt _except
+
+runExceptAt ∷
+  ∀ t e a r s
+  . IsSymbol s
+  ⇒ RowCons s (EXCEPT e) t r
+  ⇒ SProxy s
+  → Run r a
+  → Run t (Either e a)
+runExceptAt sym = loop
   where
-  handle = Run.on _except Left Right
+  handle = Run.on sym Left Right
   loop r = case Run.peel r of
     Left a → case handle a of
       Left (Except e) →
         pure (Left e)
       Right a' →
-        Run.send a' >>= runExcept
+        Run.send a' >>= runExceptAt sym
     Right a →
       pure (Right a)
 
 runFail ∷ ∀ a r. Run (except ∷ FAIL | r) a → Run r (Maybe a)
-runFail = map (either (const Nothing) Just) <<< runExcept
+runFail = runFailAt _except
+
+runFailAt ∷
+  ∀ t a r s
+  . IsSymbol s
+  ⇒ RowCons s FAIL t r
+  ⇒ SProxy s
+  → Run r a
+  → Run t (Maybe a)
+runFailAt sym = map (either (const Nothing) Just) <<< runExceptAt sym

--- a/src/Run/State.purs
+++ b/src/Run/State.purs
@@ -3,17 +3,27 @@ module Run.State
   , STATE
   , _state
   , liftState
+  , liftStateAt
   , modify
+  , modifyAt
   , put
+  , putAt
   , get
+  , getAt
   , gets
+  , getsAt
   , runState
+  , runStateAt
   , evalState
+  , evalStateAt
   , execState
+  , execStateAt
   ) where
 
 import Prelude
+
 import Data.Either (Either(..))
+import Data.Symbol (class IsSymbol)
 import Data.Tuple (Tuple(..), fst, snd)
 import Run (Run, SProxy(..), FProxy)
 import Run as Run
@@ -28,36 +38,110 @@ _state ∷ SProxy "state"
 _state = SProxy
 
 liftState ∷ ∀ s a r. State s a → Run (state ∷ STATE s | r) a
-liftState = Run.lift _state
+liftState = liftStateAt _state
+
+liftStateAt ∷
+  ∀ q sym s a r
+  . IsSymbol sym
+  ⇒ RowCons sym (STATE s) q r
+  ⇒ SProxy sym
+  → State s a
+  → Run r a
+liftStateAt = Run.lift
 
 modify ∷ ∀ s r. (s → s) → Run (state ∷ STATE s | r) Unit
-modify f = liftState $ State f (const unit)
+modify = modifyAt _state
+
+modifyAt ∷
+  ∀ q sym s r
+  . IsSymbol sym
+  ⇒ RowCons sym (STATE s) q r
+  ⇒ SProxy sym
+  → (s → s)
+  → Run r Unit
+modifyAt sym f = liftStateAt sym $ State f (const unit)
 
 put ∷ ∀ s r. s → Run (state ∷ STATE s | r) Unit
-put = modify <<< const
+put = putAt _state
+
+putAt ∷
+  ∀ q sym s r
+  . IsSymbol sym
+  ⇒ RowCons sym (STATE s) q r
+  ⇒ SProxy sym
+  → s
+  → Run r Unit
+putAt sym = modifyAt sym <<< const
 
 get ∷ ∀ s r. Run (state ∷ STATE s | r) s
-get = liftState $ State id id
+get = getAt _state
+
+getAt ∷
+  ∀ q sym s r
+  . IsSymbol sym
+  ⇒ RowCons sym (STATE s) q r
+  ⇒ SProxy sym
+  → Run r s
+getAt sym = liftStateAt sym $ State id id
 
 gets ∷ ∀ s t r. (s → t) → Run (state ∷ STATE s | r) t
-gets = flip map get
+gets = getsAt _state
+
+getsAt ∷
+  ∀ q sym s t r
+  . IsSymbol sym
+  ⇒ RowCons sym (STATE s) q r
+  ⇒ SProxy sym
+  → (s → t)
+  → Run r t
+getsAt sym = flip map (getAt sym)
 
 runState ∷ ∀ s r a. s → Run (state ∷ STATE s | r) a → Run r (Tuple s a)
-runState = loop
+runState = runStateAt _state
+
+runStateAt ∷
+  ∀ q sym s r a
+  . IsSymbol sym
+  ⇒ RowCons sym (STATE s) q r
+  ⇒ SProxy sym
+  → s
+  → Run r a
+  → Run q (Tuple s a)
+runStateAt sym = loop
   where
-  handle = Run.on _state Left Right
+  handle = Run.on sym Left Right
   loop s r = case Run.peel r of
     Left a → case handle a of
       Left (State t k) →
         let s' = t s
         in loop s' (k s')
       Right a' →
-        Run.send a' >>= runState s
+        Run.send a' >>= runStateAt sym s
     Right a →
       pure (Tuple s a)
 
 evalState ∷ ∀ s r a. s → Run (state ∷ STATE s | r) a → Run r a
-evalState s = map snd <<< runState s
+evalState = evalStateAt _state
+
+evalStateAt ∷
+  ∀ q sym s r a
+  . IsSymbol sym
+  ⇒ RowCons sym (STATE s) q r
+  ⇒ SProxy sym
+  → s
+  → Run r a
+  → Run q a
+evalStateAt sym s = map snd <<< runStateAt sym s
 
 execState ∷ ∀ s r a. s → Run (state ∷ STATE s | r) a → Run r s
-execState s = map fst <<< runState s
+execState = execStateAt _state
+
+execStateAt ∷
+  ∀ q sym s r a
+  . IsSymbol sym
+  ⇒ RowCons sym (STATE s) q r
+  ⇒ SProxy sym
+  → s
+  → Run r a
+  → Run q s
+execStateAt sym s = map fst <<< runStateAt sym s

--- a/src/Run/Writer.purs
+++ b/src/Run/Writer.purs
@@ -3,15 +3,22 @@ module Run.Writer
   , WRITER
   , _writer
   , liftWriter
+  , liftWriterAt
   , tell
+  , tellAt
   , censor
+  , censorAt
   , foldWriter
+  , foldWriterAt
   , runWriter
+  , runWriterAt
   ) where
 
 import Prelude
+
 import Data.Either (Either(..))
 import Data.Monoid (class Monoid, mempty)
+import Data.Symbol (class IsSymbol)
 import Data.Tuple (Tuple(..))
 import Run (Run, SProxy(..), FProxy)
 import Run as Run
@@ -26,37 +33,86 @@ _writer ∷ SProxy "writer"
 _writer = SProxy
 
 liftWriter ∷ ∀ w a r. Writer w a → Run (writer ∷ WRITER w | r) a
-liftWriter = Run.lift _writer
+liftWriter = liftWriterAt _writer
+
+liftWriterAt ∷
+  ∀ w a r t s
+  . IsSymbol s
+  ⇒ RowCons s (WRITER w) t r
+  ⇒ SProxy s
+  → Writer w a
+  → Run r a
+liftWriterAt = Run.lift
 
 tell ∷ ∀ w r. w → Run (writer ∷ WRITER w | r) Unit
-tell w = liftWriter (Writer w unit)
+tell = tellAt _writer
+
+tellAt ∷
+  ∀ w r t s
+  . IsSymbol s
+  ⇒ RowCons s (WRITER w) t r
+  ⇒ SProxy s
+  → w
+  → Run r Unit
+tellAt sym w = liftWriterAt sym (Writer w unit)
 
 censor ∷ ∀ w a r. (w → w) → Run (writer ∷ WRITER w | r) a → Run (writer ∷ WRITER w | r) a
-censor = loop
+censor = censorAt _writer
+
+censorAt ∷
+  ∀ w a r t s
+  . IsSymbol s
+  ⇒ RowCons s (WRITER w) t r
+  ⇒ SProxy s
+  → (w → w)
+  → Run r a
+  → Run r a
+censorAt sym = loop
   where
-  handle = Run.on _writer Left Right
+  handle = Run.on sym Left Right
   loop f r = case Run.peel r of
     Left a → case handle a of
       Left (Writer w n) → do
-        tell (f w)
-        censor f n
+        tellAt sym (f w)
+        censorAt sym f n
       Right _ →
-        Run.send a >>= censor f
+        Run.send a >>= censorAt sym f
     Right a →
       pure a
 
 foldWriter ∷ ∀ w b a r. (b → w → b) → b → Run (writer ∷ WRITER w | r) a → Run r (Tuple b a)
-foldWriter = loop
+foldWriter = foldWriterAt _writer
+
+foldWriterAt ∷
+  ∀ w b a r t s
+  . IsSymbol s
+  ⇒ RowCons s (WRITER w) t r
+  ⇒ SProxy s
+  → (b → w → b)
+  → b
+  → Run r a
+  → Run t (Tuple b a)
+foldWriterAt sym = loop
   where
-  handle = Run.on _writer Left Right
+  handle = Run.on sym Left Right
   loop k w r = case Run.peel r of
     Left a → case handle a of
       Left (Writer w' n) →
         loop k (k w w') n
       Right a' →
-        Run.send a' >>= foldWriter k w
+        Run.send a' >>= foldWriterAt sym k w
     Right a →
       pure (Tuple w a)
 
 runWriter ∷ ∀ w a r. Monoid w ⇒ Run (writer ∷ WRITER w | r) a → Run r (Tuple w a)
-runWriter = foldWriter (<>) mempty
+runWriter = runWriterAt _writer
+
+runWriterAt ∷
+  ∀ w a r t s
+  . IsSymbol s
+  ⇒ Monoid w
+  ⇒ RowCons s (WRITER w) t r
+  ⇒ SProxy s
+  → Run r a
+  → Run t (Tuple w a)
+runWriterAt sym = foldWriterAt sym (<>) mempty

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -10,7 +10,7 @@ import Data.Foldable (for_, oneOfMap)
 import Run (EFF, FProxy, Run, SProxy(..), lift, liftEff, on, extract, runBaseEff, run, send)
 import Run.Choose (CHOOSE, runChoose)
 import Run.Except (EXCEPT, catch, runExcept, runExceptAt, throw, throwAt)
-import Run.State (STATE, runState, get, gets, put, modify)
+import Run.State (STATE, get, gets, modify, put, putAt, runState, runStateAt)
 import Test.Examples as Examples
 
 data Talk a
@@ -53,15 +53,18 @@ program3 = do
   name ← listen
   speak $ "Nice to meet you, " <> name <> "!"
 
-program4 ∷ ∀ r. String → Run (exc ∷ EXCEPT String, state ∷ STATE String | r) Int
+program4 ∷ ∀ r. String → Run (exc ∷ EXCEPT String, st ∷ STATE String | r) Int
 program4 a = do
-  put "Hello"
+  putAt _st "Hello"
   if a == "12"
-    then put "World" $> 12
+    then putAt _st "World" $> 12
     else throwAt _exc "Not 12"
 
 _exc ∷ SProxy "exc"
 _exc = SProxy
+
+_st ∷ SProxy "st"
+_st = SProxy
 
 type MyEffects eff =
   ( state ∷ STATE Int
@@ -101,9 +104,9 @@ main = do
     # run runSpeak
     # runBaseEff
 
-  program4 "42" # runState "" # runExceptAt _exc # extract # logShow
-  program4 "42" # runExceptAt _exc # runState "" # extract # logShow
-  program4 "12" # runState "" # runExceptAt _exc # extract # logShow
+  program4 "42" # runStateAt _st "" # runExceptAt _exc # extract # logShow
+  program4 "42" # runExceptAt _exc # runStateAt _st "" # extract # logShow
+  program4 "12" # runStateAt _st "" # runExceptAt _exc # extract # logShow
 
   yesProgram
     # catch (liftEff <<< log)


### PR DESCRIPTION
Re: #12.

Adds the `At` alternates for most all of the functions. Doesn't add unlabeled alternates for `Run.Choose` as that has typeclass stuff going on.

Let me know if there's anything you'd like changed.