### PR TITLE
Update installation instructions to use Spago

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ implementation for PureScript.
 ## Install
 
 ```
-bower install purescript-run
+spago install run
 ```
 
 ## Documentation


### PR DESCRIPTION
Small tweak that points users to Spago instead of Bower for installation.