### PR TITLE
Update for PureScript 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ implementation for PureScript.
 ## Install
 
 ```
-bower install purescript-run
+spago install run
 ```
 
 ## Documentation
@@ -81,6 +81,7 @@ main = foldFree go program
     Listen reply -> do
       pure (reply "I am Groot")
 ```
+
 ```
 Hello, what is your name?
 Nice to meet you, I am Groot

--- a/README.md
+++ b/README.md
@@ -171,35 +171,35 @@ PureScript. If we look at its big brother `VariantF` (found in
 `Functor`s and works like an extensible `Coproduct`.
 
 ```purescript
-type TALK = FProxy TalkF
+type TALK r = (talk :: TalkF | r)
 
-_talk = SProxy :: SProxy "talk"
+_talk = Proxy :: Proxy "talk"
 
-speak :: forall r. String -> Free (VariantF (talk :: TALK | r)) Unit
+speak :: forall r. String -> Free (VariantF (TALK + r)) Unit
 speak str = liftF (inj _talk (Speak str unit))
 
-listen :: forall r. Free (VariantF (talk :: TALK | r)) String
+listen :: forall r. Free (VariantF (TALK + r)) String
 listen = liftF (inj _talk (Listen identity))
 
 ---
 
-type DINNER = FProxy DinnerF
+type DINNER r = (dinner :: DinnerF | r)
 
-_dinner = SProxy :: SProxy "dinner"
+_dinner = Proxy :: Proxy "dinner"
 
-eat :: forall r. Food -> Free (VariantF (dinner :: DINNER | r)) IsThereMore
+eat :: forall r. Food -> Free (VariantF (DINNER + r)) IsThereMore
 eat food = liftF (inj _dinner (Eat food identity))
 
-checkPlease :: forall r. Free (VariantF (dinner :: DINNER | r)) Bill
+checkPlease :: forall r. Free (VariantF (DINNER + r)) Bill
 checkPlease = liftF (inj _dinner (CheckPlease identity))
 ```
 
 Now our DSLs can be used together without any extra lifting.
 
 ```purescript
-type LovelyEvening r = (dinner :: DINNER, talk :: TALK | r)
+type LovelyEvening r = (DINNER + TALK + r)
 
-dinnerTime :: forall r. Free (VariantF (LovelyEvening r)) Unit
+dinnerTime :: forall r. Free (VariantF (LovelyEvening + r)) Unit
 dinnerTime = do
   speak "I'm famished!"
   isThereMore <- eat Pizza
@@ -228,17 +228,17 @@ data TalkF a
   = Speak String a
   | Listen (String -> a)
 
-type TALK = FProxy TalkF
+type TALK r = (talk :: TalkF | r)
 
-_talk = SProxy :: SProxy "talk"
+_talk = Proxy :: Proxy "talk"
 
-speak :: forall r. String -> Run (talk :: TALK | r) Unit
+speak :: forall r. String -> Run (TALK + r) Unit
 speak str = Run.lift _talk (Speak str unit)
 
-listen :: forall r. Run (talk :: TALK | r) String
+listen :: forall r. Run (TALK + r) String
 listen = Run.lift _talk (Listen identity)
 
-program :: forall r. Run (talk :: TALK | r) Unit
+program :: forall r. Run (TALK + r) Unit
 program = do
   speak $ "Hello, what is your name?"
   name <- listen
@@ -279,19 +279,19 @@ so you might need more annotations (or eta expansion) than if you had used
 Let's try adding back in our other effect for a lovely evening:
 
 ```purescript
-type DINNER = FProxy DinnerF
+type DINNER r = (dinner :: DinnerF | r)
 
-_dinner :: SProxy :: SProxy "dinner"
+_dinner :: Proxy :: Proxy "dinner"
 
-eat :: forall r. Food -> Run (dinner :: DINNER | r) IsThereMore
+eat :: forall r. Food -> Run (DINNER + r) IsThereMore
 eat food = Run.lift _dinner (Eat food identity)
 
-checkPlease :: forall r. Run (dinner :: DINNER | r) Bill
+checkPlease :: forall r. Run (DINNER + r) Bill
 checkPlease = Run.lift _dinner (CheckPlease identity)
 
-type LovelyEvening r = (talk :: TALK, dinner :: DINNER | r)
+type LovelyEvening r = (TALK + DINNER + r)
 
-dinnerTime :: forall r. Run (LovelyEvening r) Unit
+dinnerTime :: forall r. Run (LovelyEvening + r) Unit
 dinnerTime = do
   speak "I'm famished!"
   isThereMore <- eat Pizza
@@ -310,7 +310,7 @@ all effects. Instead we can use `send` for unmatched cases.
 
 ```purescript
 -- This now interprets it back into `Run` but with the `EFFECT` effect.
-handleTalk :: forall r. TalkF ~> Run (effect :: EFFECT | r)
+handleTalk :: forall r. TalkF ~> Run (EFFECT + r)
 handleTalk = case _ of
   Speak str next -> do
     -- `liftEffect` lifts native `Effect` effects into `Run`.
@@ -321,11 +321,11 @@ handleTalk = case _ of
 
 runTalk
   :: forall r
-   . Run (effect :: EFFECT, talk :: TALK | r)
-  ~> Run (effect :: EFFECT | r)
+   . Run (EFFECT + TALK + r)
+  ~> Run (EFFECT + r)
 runTalk = interpret (on _talk handleTalk send)
 
-program2 :: forall r. Run (effect :: EFFECT, dinner :: DINNER | r) Unit
+program2 :: forall r. Run (EFFECT + DINNER + r) Unit
 program2 = dinnerTime # runTalk
 ```
 
@@ -357,12 +357,12 @@ handleDinner tally = case _ of
 
 -- We eliminate the `DINNER` effect altogether, yielding the result
 -- together with the final bill.
-runDinnerPure :: forall r a. Tally -> Run (dinner :: DINNER | r) a -> Run r (Tuple Bill a)
+runDinnerPure :: forall r a. Tally -> Run (DINNER + r) a -> Run r (Tuple Bill a)
 runDinnerPure = runAccumPure
   (\tally -> on _dinner (Loop <<< handleDinner tally) Done)
   (\tally a -> Tuple tally.bill a)
 
-program3 :: forall r. Run (effect :: EFFECT | r) (Tuple Bill Unit)
+program3 :: forall r. Run (EFFECT + r) (Tuple Bill Unit)
 program3 = program2 # runDinnerPure { stock: 10, bill: 0 }
 ```
 
@@ -390,11 +390,11 @@ data LogF a = Log String a
 
 derive instance functorLogF :: Functor LogF
 
-type LOG = FProxy LogF
+type LOG r = (log :: LogF | r)
 
-_log = SProxy :: SProxy "log"
+_log = Proxy :: Proxy "log"
 
-log :: forall r. String -> Run (log :: LOG | r) Unit
+log :: forall r. String -> Run (LOG + r) Unit
 log str = Run.lift _log (Log str unit)
 
 ---
@@ -403,16 +403,16 @@ data SleepF a = Sleep Int a
 
 derive instance functorSleepF :: Functor SleepF
 
-type SLEEP = FProxy SleepF
+type SLEEP r = (sleep :: SleepF | r)
 
-_sleep = SProxy :: SProxy "sleep"
+_sleep = Proxy :: Proxy "sleep"
 
-sleep :: forall r. Int -> Run (sleep :: SLEEP | r) Unit
+sleep :: forall r. Int -> Run (SLEEP + r) Unit
 sleep ms = Run.lift _sleep (Sleep ms unit)
 
 ---
 
-program :: forall r. Run (sleep :: SLEEP, log :: LOG | r) Unit
+program :: forall r. Run (SLEEP + LOG + r) Unit
 program = do
   log "I guess I'll wait..."
   sleep 3000

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/natefaubion/purescript-run.git"
+    "url": "https://github.com/natefaubion/purescript-run.git"
   },
   "ignore": [
     "**/.*",
@@ -23,24 +23,24 @@
     "test"
   ],
   "dependencies": {
-    "purescript-aff": "^5.0.0",
-    "purescript-either": "^4.0.0",
-    "purescript-free": "^5.0.0",
-    "purescript-maybe": "^4.0.0",
-    "purescript-newtype": "^3.0.0",
-    "purescript-prelude": "^4.0.0",
-    "purescript-tailrec": "^4.0.0",
-    "purescript-tuples": "^5.0.0",
-    "purescript-type-equality": "^3.0.0",
-    "purescript-unsafe-coerce": "^4.0.0",
-    "purescript-variant": "^6.0.1",
-    "purescript-profunctor": "^4.0.0",
-    "purescript-effect": "^2.0.0"
+    "purescript-aff": "^6.0.0",
+    "purescript-either": "^5.0.0",
+    "purescript-free": "^6.0.0",
+    "purescript-maybe": "^5.0.0",
+    "purescript-newtype": "^4.0.0",
+    "purescript-prelude": "^5.0.0",
+    "purescript-tailrec": "^5.0.0",
+    "purescript-tuples": "^6.0.0",
+    "purescript-type-equality": "^4.0.0",
+    "purescript-unsafe-coerce": "^5.0.0",
+    "purescript-variant": "^7.0.1",
+    "purescript-profunctor": "^5.0.0",
+    "purescript-effect": "^3.0.0"
   },
   "devDependencies": {
-    "purescript-control": "^4.0.0",
-    "purescript-minibench": "^2.0.0",
-    "purescript-identity": "^4.0.0",
-    "purescript-console": "^4.1.0"
+    "purescript-control": "^5.0.0",
+    "purescript-minibench": "^3.0.0",
+    "purescript-identity": "^5.0.0",
+    "purescript-console": "^5.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,8 @@
     "purescript-unsafe-coerce": "^5.0.0",
     "purescript-variant": "^7.0.1",
     "purescript-profunctor": "^5.0.0",
-    "purescript-effect": "^3.0.0"
+    "purescript-effect": "^3.0.0",
+    "purescript-typelevel-prelude": "^6.0.0"
   },
   "devDependencies": {
     "purescript-control": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "ide": "purs ide server"
   },
   "devDependencies": {
-    "pulp": "^12.0.1",
-    "purescript": "^0.12.0",
-    "purescript-psa": "^0.6.0"
+    "pulp": "^15.0.0",
+    "purescript": "^0.14.0",
+    "purescript-psa": "^0.8.2"
   }
 }

--- a/src/Run.purs
+++ b/src/Run.purs
@@ -58,11 +58,13 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | effect Monad.
 -- |
 -- | An example using `State` and `Except`:
+-- |
 -- | ```purescript
 -- | type MyEffects =
--- |   ( state :: STATE Int
--- |   , except :: EXCEPT String
--- |   , effect :: EFFECT
+-- |   ( STATE Int
+-- |   + EXCEPT String
+-- |   + EFFECT
+-- |   + ()
 -- |   )
 -- |
 -- | yesProgram :: Run MyEffects Unit
@@ -113,7 +115,7 @@ instance monadRecRun :: MonadRec (Run r) where
 -- | `Proxy` slot.
 lift
   :: forall proxy sym r1 r2 f a
-  . Row.Cons sym f r1 r2
+   . Row.Cons sym f r1 r2
   => IsSymbol sym
   => Functor f
   => proxy sym
@@ -125,14 +127,14 @@ lift p = Run <<< liftF <<< inj p
 -- | instructions.
 peel
   :: forall a r
-  . Run r a
+   . Run r a
   -> Either (VariantF r (Run r a)) a
 peel = resume Left Right
 
 -- | Eliminator for the `Run` data type.
 resume
   :: forall a b r
-  . (VariantF r (Run r a) -> b)
+   . (VariantF r (Run r a) -> b)
   -> (a -> b)
   -> Run r a
   -> b
@@ -141,7 +143,7 @@ resume k1 k2 = resume' (\x f -> k1 (Run <<< f <$> x)) k2 <<< unwrap
 -- | Enqueues an instruction in the `Run` Monad.
 send
   :: forall a r
-  . VariantF r a
+   . VariantF r a
   -> Run r a
 send = Run <<< liftF
 
@@ -151,8 +153,8 @@ send = Run <<< liftF
 -- | occur.
 -- |
 -- | ```purescript
--- | type LessRows = (foo :: FOO)
--- | type MoreRows = (foo :: FOO, bar :: BAR, baz :: BAZ)
+-- | type LessRows = (foo :: Foo)
+-- | type MoreRows = (foo :: Foo, bar :: Bar, baz :: Baz)
 -- |
 -- | foo :: Run LessRows Unit
 -- | foo = foo
@@ -162,7 +164,7 @@ send = Run <<< liftF
 -- | ```
 expand
   :: forall r1 r2 rx a
-  . Row.Union r1 rx r2
+   . Row.Union r1 rx r2
   => Run r1 a
   -> Run r2 a
 expand = unsafeCoerce
@@ -175,7 +177,7 @@ extract = unwrap >>> runFree \_ -> unsafeCrashWith "Run: the impossible happened
 -- | stack safety under Monadic recursion.
 interpret
   :: forall m a r
-  . Monad m
+   . Monad m
   => (VariantF r ~> m)
   -> Run r a
   -> m a
@@ -185,7 +187,7 @@ interpret = run
 -- | letting you intercept the rest of the program.
 run
   :: forall m a r
-  . Monad m
+   . Monad m
   => (VariantF r (Run r a) -> m (Run r a))
   -> Run r a
   -> m a
@@ -198,7 +200,7 @@ run k = loop
 -- | stack safety.
 interpretRec
   :: forall m a r
-  . MonadRec m
+   . MonadRec m
   => (VariantF r ~> m)
   -> Run r a
   -> m a
@@ -208,7 +210,7 @@ interpretRec = runRec
 -- | signature, letting you intercept the rest of the program.
 runRec
   :: forall m a r
-  . MonadRec m
+   . MonadRec m
   => (VariantF r (Run r a) -> m (Run r a))
   -> Run r a
   -> m a
@@ -221,7 +223,7 @@ runRec k = runFreeM (coerceM k) <<< unwrap
 -- | Extracts the value from a program via some `m` using continuation passing.
 runCont
   :: forall m a b r
-  . (VariantF r (m b) -> m b)
+   . (VariantF r (m b) -> m b)
   -> (a -> m b)
   -> Run r a
   -> m b
@@ -234,7 +236,7 @@ runCont k1 k2 = loop
 -- | accumulator. This assumes stack safety under Monadic recursion.
 runAccum
   :: forall m r s a
-  . Monad m
+   . Monad m
   => (s -> VariantF r (Run r a) -> m (Tuple s (Run r a)))
   -> s
   -> Run r a
@@ -248,7 +250,7 @@ runAccum k = loop
 -- | accumulator.
 runAccumRec
   :: forall m r s a
-  . MonadRec m
+   . MonadRec m
   => (s -> VariantF r (Run r a) -> m (Tuple s (Run r a)))
   -> s
   -> Run r a
@@ -262,7 +264,7 @@ runAccumRec k = curry (tailRecM (uncurry loop))
 -- | with an internal accumulator.
 runAccumCont
   :: forall m r s a b
-  . (s -> VariantF r (s -> m b) -> m b)
+   . (s -> VariantF r (s -> m b) -> m b)
   -> (s -> a -> m b)
   -> s
   -> Run r a
@@ -276,7 +278,7 @@ runAccumCont k1 k2 = loop
 -- | preserve stack safety under tail recursion.
 runPure
   :: forall r1 r2 a
-  . (VariantF r1 (Run r1 a) -> Step (Run r1 a) (VariantF r2 (Run r1 a)))
+   . (VariantF r1 (Run r1 a) -> Step (Run r1 a) (VariantF r2 (Run r1 a)))
   -> Run r1 a
   -> Run r2 a
 runPure k = loop
@@ -293,7 +295,7 @@ runPure k = loop
 -- | `Control.Monad.Rec.Class` to preserve stack safety under tail recursion.
 runAccumPure
   :: forall r1 r2 a b s
-  . (s -> VariantF r1 (Run r1 a) -> Step (Tuple s (Run r1 a)) (VariantF r2 (Run r1 a)))
+   . (s -> VariantF r1 (Run r1 a) -> Step (Tuple s (Run r1 a)) (VariantF r2 (Run r1 a)))
   -> (s -> a -> b)
   -> s
   -> Run r1 a

--- a/src/Run.purs
+++ b/src/Run.purs
@@ -104,7 +104,7 @@ instance monadRecRun :: MonadRec (Run r) where
   tailRecM f = loop
     where
     loop a = do
-      b ← f a
+      b <- f a
       case b of
         Done r -> pure r
         Loop n -> loop n

--- a/src/Run.purs
+++ b/src/Run.purs
@@ -60,12 +60,12 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | An example using `State` and `Except`:
 -- | ```purescript
 -- | type MyEffects =
--- |   ( state ∷ STATE Int
--- |   , except ∷ EXCEPT String
--- |   , effect ∷ EFFECT
+-- |   ( state :: STATE Int
+-- |   , except :: EXCEPT String
+-- |   , effect :: EFFECT
 -- |   )
 -- |
--- | yesProgram ∷ Run MyEffects Unit
+-- | yesProgram :: Run MyEffects Unit
 -- | yesProgram = do
 -- |   whenM (gets (_ < 0)) do
 -- |     throw "Number is less than 0"
@@ -74,11 +74,11 @@ import Unsafe.Coerce (unsafeCoerce)
 -- |     modify (_ - 1)
 -- |   where
 -- |   whileM_
--- |     ∷ ∀ a
+-- |     :: forall a
 -- |     . Run MyEffects Boolean
--- |     → Run MyEffects a
--- |     → Run MyEffects Unit
--- |   whileM_ mb ma = flip tailRecM unit \a →
+-- |     -> Run MyEffects a
+-- |     -> Run MyEffects Unit
+-- |   whileM_ mb ma = flip tailRecM unit \a ->
 -- |     mb >>= if _ then ma $> Loop unit else pure $ Done unit
 -- |
 -- | main =
@@ -90,59 +90,59 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | ````
 newtype Run r a = Run (Free (VariantF r) a)
 
-derive instance newtypeRun ∷ Newtype (Run r a) _
-derive newtype instance functorRun ∷ Functor (Run r)
-derive newtype instance applyRun ∷ Apply (Run r)
-derive newtype instance applicativeRun ∷ Applicative (Run r)
-derive newtype instance bindRun ∷ Bind (Run r)
-derive newtype instance monadRun ∷ Monad (Run r)
+derive instance newtypeRun :: Newtype (Run r a) _
+derive newtype instance functorRun :: Functor (Run r)
+derive newtype instance applyRun :: Apply (Run r)
+derive newtype instance applicativeRun :: Applicative (Run r)
+derive newtype instance bindRun :: Bind (Run r)
+derive newtype instance monadRun :: Monad (Run r)
 
 -- | This instance is provided for compatibility, but is otherwise
 -- | unnecessary. You can use monadic recursion with `Run`, deferring the
 -- | `MonadRec` constraint till it is interpretted.
-instance monadRecRun ∷ MonadRec (Run r) where
+instance monadRecRun :: MonadRec (Run r) where
   tailRecM f = loop
     where
     loop a = do
       b ← f a
       case b of
-        Done r → pure r
-        Loop n → loop n
+        Done r -> pure r
+        Loop n -> loop n
 
 -- | Lifts an effect functor into the `Run` Monad according to the provided
 -- | `Proxy` slot.
 lift
-  ∷ ∀ proxy sym r1 r2 f a
+  :: forall proxy sym r1 r2 f a
   . Row.Cons sym f r1 r2
-  ⇒ IsSymbol sym
-  ⇒ Functor f
-  ⇒ proxy sym
-  → f a
-  → Run r2 a
+  => IsSymbol sym
+  => Functor f
+  => proxy sym
+  -> f a
+  -> Run r2 a
 lift p = Run <<< liftF <<< inj p
 
 -- | Reflects the next instruction or the final value if there are no more
 -- | instructions.
 peel
-  ∷ ∀ a r
+  :: forall a r
   . Run r a
-  → Either (VariantF r (Run r a)) a
+  -> Either (VariantF r (Run r a)) a
 peel = resume Left Right
 
 -- | Eliminator for the `Run` data type.
 resume
-  ∷ ∀ a b r
-  . (VariantF r (Run r a) → b)
-  → (a → b)
-  → Run r a
-  → b
-resume k1 k2 = resume' (\x f → k1 (Run <<< f <$> x)) k2 <<< unwrap
+  :: forall a b r
+  . (VariantF r (Run r a) -> b)
+  -> (a -> b)
+  -> Run r a
+  -> b
+resume k1 k2 = resume' (\x f -> k1 (Run <<< f <$> x)) k2 <<< unwrap
 
 -- | Enqueues an instruction in the `Run` Monad.
 send
-  ∷ ∀ a r
+  :: forall a r
   . VariantF r a
-  → Run r a
+  -> Run r a
 send = Run <<< liftF
 
 -- | Casts some set of effects to a wider set of effects via a left-biased
@@ -151,204 +151,204 @@ send = Run <<< liftF
 -- | occur.
 -- |
 -- | ```purescript
--- | type LessRows = (foo ∷ FOO)
--- | type MoreRows = (foo ∷ FOO, bar ∷ BAR, baz ∷ BAZ)
+-- | type LessRows = (foo :: FOO)
+-- | type MoreRows = (foo :: FOO, bar :: BAR, baz :: BAZ)
 -- |
--- | foo ∷ Run LessRows Unit
+-- | foo :: Run LessRows Unit
 -- | foo = foo
 -- |
--- | foo' ∷ Run MoreRows Unit
+-- | foo' :: Run MoreRows Unit
 -- | foo' = expand foo
 -- | ```
 expand
-  ∷ ∀ r1 r2 rx a
+  :: forall r1 r2 rx a
   . Row.Union r1 rx r2
-  ⇒ Run r1 a
-  → Run r2 a
+  => Run r1 a
+  -> Run r2 a
 expand = unsafeCoerce
 
 -- | Extracts the value from a purely interpreted program.
-extract ∷ ∀ a. Run () a → a
-extract = unwrap >>> runFree \_ → unsafeCrashWith "Run: the impossible happened"
+extract :: forall a. Run () a -> a
+extract = unwrap >>> runFree \_ -> unsafeCrashWith "Run: the impossible happened"
 
 -- | Extracts the value from a program via some Monad `m`. This assumes
 -- | stack safety under Monadic recursion.
 interpret
-  ∷ ∀ m a r
+  :: forall m a r
   . Monad m
-  ⇒ (VariantF r ~> m)
-  → Run r a
-  → m a
+  => (VariantF r ~> m)
+  -> Run r a
+  -> m a
 interpret = run
 
 -- | Identical to `interpret` but with a less restrictive type signature,
 -- | letting you intercept the rest of the program.
 run
-  ∷ ∀ m a r
+  :: forall m a r
   . Monad m
-  ⇒ (VariantF r (Run r a) → m (Run r a))
-  → Run r a
-  → m a
+  => (VariantF r (Run r a) -> m (Run r a))
+  -> Run r a
+  -> m a
 run k = loop
   where
-  loop ∷ Run r a → m a
-  loop = resume (\a → loop =<< k a) pure
+  loop :: Run r a -> m a
+  loop = resume (\a -> loop =<< k a) pure
 
 -- | Extracts the value from a program via some MonadRec `m`, preserving
 -- | stack safety.
 interpretRec
-  ∷ ∀ m a r
+  :: forall m a r
   . MonadRec m
-  ⇒ (VariantF r ~> m)
-  → Run r a
-  → m a
+  => (VariantF r ~> m)
+  -> Run r a
+  -> m a
 interpretRec = runRec
 
 -- | Identical to `interpretRec` but with a less restrictive type
 -- | signature, letting you intercept the rest of the program.
 runRec
-  ∷ ∀ m a r
+  :: forall m a r
   . MonadRec m
-  ⇒ (VariantF r (Run r a) → m (Run r a))
-  → Run r a
-  → m a
+  => (VariantF r (Run r a) -> m (Run r a))
+  -> Run r a
+  -> m a
 runRec k = runFreeM (coerceM k) <<< unwrap
   where
   -- Just so we can avoid the overhead of mapping the Run constructor
-  coerceM ∷ (VariantF r (Run r a) -> m (Run r a)) -> VariantF r (Free (VariantF r) a) -> m (Free (VariantF r) a)
+  coerceM :: (VariantF r (Run r a) -> m (Run r a)) -> VariantF r (Free (VariantF r) a) -> m (Free (VariantF r) a)
   coerceM = unsafeCoerce
 
 -- | Extracts the value from a program via some `m` using continuation passing.
 runCont
-  ∷ ∀ m a b r
-  . (VariantF r (m b) → m b)
-  → (a → m b)
-  → Run r a
-  → m b
+  :: forall m a b r
+  . (VariantF r (m b) -> m b)
+  -> (a -> m b)
+  -> Run r a
+  -> m b
 runCont k1 k2 = loop
   where
-  loop ∷ Run r a → m b
+  loop :: Run r a -> m b
   loop = resume (\b -> k1 (loop <$> b)) k2
 
 -- | Extracts the value from a program via some Monad `m` with an internal
 -- | accumulator. This assumes stack safety under Monadic recursion.
 runAccum
-  ∷ ∀ m r s a
+  :: forall m r s a
   . Monad m
-  ⇒ (s → VariantF r (Run r a) → m (Tuple s (Run r a)))
-  → s
-  → Run r a
-  → m a
+  => (s -> VariantF r (Run r a) -> m (Tuple s (Run r a)))
+  -> s
+  -> Run r a
+  -> m a
 runAccum k = loop
   where
-  loop ∷ s → Run r a → m a
-  loop s = resume (\b → uncurry loop =<< k s b) pure
+  loop :: s -> Run r a -> m a
+  loop s = resume (\b -> uncurry loop =<< k s b) pure
 
 -- | Extracts the value from a program via some MonadRec `m` with an internal
 -- | accumulator.
 runAccumRec
-  ∷ ∀ m r s a
+  :: forall m r s a
   . MonadRec m
-  ⇒ (s → VariantF r (Run r a) → m (Tuple s (Run r a)))
-  → s
-  → Run r a
-  → m a
+  => (s -> VariantF r (Run r a) -> m (Tuple s (Run r a)))
+  -> s
+  -> Run r a
+  -> m a
 runAccumRec k = curry (tailRecM (uncurry loop))
   where
-  loop ∷ s → Run r a → m (Step (Tuple s (Run r a)) a)
-  loop s = resume (\b → Loop <$> k s b) (pure <<< Done)
+  loop :: s -> Run r a -> m (Step (Tuple s (Run r a)) a)
+  loop s = resume (\b -> Loop <$> k s b) (pure <<< Done)
 
 -- | Extracts the value from a program via some `m` using continuation passing
 -- | with an internal accumulator.
 runAccumCont
-  ∷ ∀ m r s a b
-  . (s → VariantF r (s → m b) → m b)
-  → (s → a → m b)
-  → s
-  → Run r a
-  → m b
+  :: forall m r s a b
+  . (s -> VariantF r (s -> m b) -> m b)
+  -> (s -> a -> m b)
+  -> s
+  -> Run r a
+  -> m b
 runAccumCont k1 k2 = loop
   where
-  loop ∷ s → Run r a → m b
-  loop s = resume (\b → k1 s (flip loop <$> b)) (k2 s)
+  loop :: s -> Run r a -> m b
+  loop s = resume (\b -> k1 s (flip loop <$> b)) (k2 s)
 
 -- | Eliminates effects purely. Uses `Step` from `Control.Monad.Rec.Class` to
 -- | preserve stack safety under tail recursion.
 runPure
-  ∷ ∀ r1 r2 a
-  . (VariantF r1 (Run r1 a) → Step (Run r1 a) (VariantF r2 (Run r1 a)))
-  → Run r1 a
-  → Run r2 a
+  :: forall r1 r2 a
+  . (VariantF r1 (Run r1 a) -> Step (Run r1 a) (VariantF r2 (Run r1 a)))
+  -> Run r1 a
+  -> Run r2 a
 runPure k = loop
   where
-  loop ∷ Run r1 a → Run r2 a
+  loop :: Run r1 a -> Run r2 a
   loop r = case peel r of
-    Left a → case k a of
-      Loop r' → loop r'
-      Done a' → send a' >>= runPure k
-    Right a →
+    Left a -> case k a of
+      Loop r' -> loop r'
+      Done a' -> send a' >>= runPure k
+    Right a ->
       pure a
 
 -- | Eliminates effects purely with an internal accumulator. Uses `Step` from
 -- | `Control.Monad.Rec.Class` to preserve stack safety under tail recursion.
 runAccumPure
-  ∷ ∀ r1 r2 a b s
-  . (s → VariantF r1 (Run r1 a) → Step (Tuple s (Run r1 a)) (VariantF r2 (Run r1 a)))
-  → (s → a → b)
-  → s
-  → Run r1 a
-  → Run r2 b
+  :: forall r1 r2 a b s
+  . (s -> VariantF r1 (Run r1 a) -> Step (Tuple s (Run r1 a)) (VariantF r2 (Run r1 a)))
+  -> (s -> a -> b)
+  -> s
+  -> Run r1 a
+  -> Run r2 b
 runAccumPure k1 k2 = loop
   where
-  loop ∷ s → Run r1 a → Run r2 b
+  loop :: s -> Run r1 a -> Run r2 b
   loop s r = case peel r of
-    Left a → case k1 s a of
-      Loop (Tuple s' r') → loop s' r'
-      Done a' → send a' >>= runAccumPure k1 k2 s
-    Right a →
+    Left a -> case k1 s a of
+      Loop (Tuple s' r') -> loop s' r'
+      Done a' -> send a' >>= runAccumPure k1 k2 s
+    Right a ->
       pure (k2 s a)
 
 -- | Type synonym for using `Effect` as an effect.
-type EFFECT r = (effect ∷ Effect | r)
+type EFFECT r = (effect :: Effect | r)
 
 -- Lift an `Effect` effect into the `Run` Monad via the `effect` label.
-liftEffect ∷ ∀ r. Effect ~> Run (EFFECT + r)
-liftEffect = lift (Proxy ∷ Proxy "effect")
+liftEffect :: forall r. Effect ~> Run (EFFECT + r)
+liftEffect = lift (Proxy :: Proxy "effect")
 
 -- | Runs a base `Effect` effect.
-runBaseEffect ∷ Run (EFFECT + ()) ~> Effect
-runBaseEffect = runRec $ match { effect: \a → a }
+runBaseEffect :: Run (EFFECT + ()) ~> Effect
+runBaseEffect = runRec $ match { effect: \a -> a }
 
 -- | Type synonym for using `Aff` as an effect.
-type AFF r = (aff ∷ Aff | r)
+type AFF r = (aff :: Aff | r)
 
 -- | Lift an `Aff` effect into the `Run` Monad via the `aff` label.
-liftAff ∷ ∀ r. Aff ~> Run (AFF + r)
-liftAff = lift (Proxy ∷ Proxy "aff")
+liftAff :: forall r. Aff ~> Run (AFF + r)
+liftAff = lift (Proxy :: Proxy "aff")
 
 -- | Runs a base `Aff` effect.
-runBaseAff ∷ Run (AFF + ()) ~> Aff
-runBaseAff = run $ match { aff: \a → a }
+runBaseAff :: Run (AFF + ()) ~> Aff
+runBaseAff = run $ match { aff: \a -> a }
 
 -- | Runs base `Aff` and `Effect` together as one effect.
-runBaseAff' ∷ Run (AFF + EFFECT + ()) ~> Aff
-runBaseAff' = run $ match { aff: \a → a, effect: \a → Effect.liftEffect a }
+runBaseAff' :: Run (AFF + EFFECT + ()) ~> Aff
+runBaseAff' = run $ match { aff: \a -> a, effect: \a -> Effect.liftEffect a }
 
-instance runMonadEffect ∷ (TypeEquals (Proxy r1) (Proxy (EFFECT r2))) ⇒ MonadEffect (Run r1) where
+instance runMonadEffect :: (TypeEquals (Proxy r1) (Proxy (EFFECT r2))) => MonadEffect (Run r1) where
   liftEffect = fromRows <<< liftEffect
 
 -- | This will insert an `EFFECT` effect because `MonadAff` entails `MonadEffect`.
 -- | If you don't want this, use `Run.liftAff` rather than `Control.Monad.Aff.Class.liftAff`.
-instance runMonadAff ∷ (TypeEquals (Proxy r1) (Proxy (AFF + EFFECT + r2))) ⇒ MonadAff (Run r1) where
+instance runMonadAff :: (TypeEquals (Proxy r1) (Proxy (AFF + EFFECT + r2))) => MonadAff (Run r1) where
   liftAff = fromRows <<< liftAff
 
-liftChoose ∷ ∀ r a. Choose a → Run (CHOOSE + r) a
+liftChoose :: forall r a. Choose a -> Run (CHOOSE + r) a
 liftChoose = lift _choose
 
-instance runAlt ∷ (TypeEquals (Proxy r1) (Proxy (CHOOSE + r2))) ⇒ Alt (Run r1) where
+instance runAlt :: (TypeEquals (Proxy r1) (Proxy (CHOOSE + r2))) => Alt (Run r1) where
   alt a b = fromRows $ liftChoose (Alt identity) >>= if _ then toRows a else toRows b
 
-instance runPlus ∷ (TypeEquals (Proxy r1) (Proxy (CHOOSE + r2))) ⇒ Plus (Run r1) where
+instance runPlus :: (TypeEquals (Proxy r1) (Proxy (CHOOSE + r2))) => Plus (Run r1) where
   empty = fromRows $ liftChoose Empty
 
-instance runAlternative ∷ (TypeEquals (Proxy r1) (Proxy (CHOOSE + r2))) ⇒ Alternative (Run r1)
+instance runAlternative :: (TypeEquals (Proxy r1) (Proxy (CHOOSE + r2))) => Alternative (Run r1)

--- a/src/Run/Choose.purs
+++ b/src/Run/Choose.purs
@@ -15,28 +15,28 @@ import Run as Run
 import Run.Internal (Choose(..), CHOOSE, _choose)
 import Type.Row (type (+))
 
-liftChoose ∷ ∀ r a. Choose a → Run (CHOOSE + r) a
+liftChoose :: forall r a. Choose a -> Run (CHOOSE + r) a
 liftChoose = Run.lift _choose
 
-cempty ∷ ∀ r a. Run (CHOOSE + r) a
+cempty :: forall r a. Run (CHOOSE + r) a
 cempty = empty
 
-calt ∷ ∀ r a. Run (CHOOSE + r) a → Run (CHOOSE + r) a → Run (CHOOSE + r) a
+calt :: forall r a. Run (CHOOSE + r) a -> Run (CHOOSE + r) a -> Run (CHOOSE + r) a
 calt = alt
 
-runChoose ∷ ∀ f a r. Alternative f ⇒ Run (CHOOSE + r) a → Run r (f a)
+runChoose :: forall f a r. Alternative f => Run (CHOOSE + r) a -> Run r (f a)
 runChoose = loop
   where
   handle = Run.on _choose Left Right
   loop r = case Run.peel r of
-    Left a → case handle a of
-      Left a' → case a' of
-        Empty → pure empty
-        Alt k → do
+    Left a -> case handle a of
+      Left a' -> case a' of
+        Empty -> pure empty
+        Alt k -> do
           x ← loop (k true)
           y ← loop (k false)
           pure (alt x y)
-      Right a' →
+      Right a' ->
         Run.send a' >>= loop
-    Right a →
+    Right a ->
         pure (pure a)

--- a/src/Run/Choose.purs
+++ b/src/Run/Choose.purs
@@ -8,22 +8,23 @@ module Run.Choose
 
 import Prelude
 
-import Control.Alternative (class Alternative, alt, empty )
+import Control.Alternative (class Alternative, alt, empty)
 import Data.Either (Either(..))
 import Run (Run)
 import Run as Run
 import Run.Internal (Choose(..), CHOOSE, _choose)
+import Type.Row (type (+))
 
-liftChoose ∷ ∀ r a. Choose a → Run (choose ∷ CHOOSE | r) a
+liftChoose ∷ ∀ r a. Choose a → Run (CHOOSE + r) a
 liftChoose = Run.lift _choose
 
-cempty ∷ ∀ r a. Run (choose ∷ CHOOSE | r) a
+cempty ∷ ∀ r a. Run (CHOOSE + r) a
 cempty = empty
 
-calt ∷ ∀ r a. Run (choose ∷ CHOOSE | r) a → Run (choose ∷ CHOOSE | r) a → Run (choose ∷ CHOOSE | r) a
+calt ∷ ∀ r a. Run (CHOOSE + r) a → Run (CHOOSE + r) a → Run (CHOOSE + r) a
 calt = alt
 
-runChoose ∷ ∀ f a r. Alternative f ⇒ Run (choose ∷ CHOOSE | r) a → Run r (f a)
+runChoose ∷ ∀ f a r. Alternative f ⇒ Run (CHOOSE + r) a → Run r (f a)
 runChoose = loop
   where
   handle = Run.on _choose Left Right

--- a/src/Run/Choose.purs
+++ b/src/Run/Choose.purs
@@ -33,8 +33,8 @@ runChoose = loop
       Left a' -> case a' of
         Empty -> pure empty
         Alt k -> do
-          x ← loop (k true)
-          y ← loop (k false)
+          x <- loop (k true)
+          y <- loop (k false)
           pure (alt x y)
       Right a' ->
         Run.send a' >>= loop

--- a/src/Run/Except.purs
+++ b/src/Run/Except.purs
@@ -29,100 +29,108 @@ import Data.Either (Either(..), either)
 import Data.Maybe (Maybe(..), maybe')
 import Data.Symbol (class IsSymbol)
 import Prim.Row as Row
-import Run (Run, SProxy(..), FProxy)
+import Run (Run)
 import Run as Run
+import Type.Proxy (Proxy(..))
+import Type.Row (type (+))
 
+newtype Except :: forall k. Type -> k -> Type
 newtype Except e a = Except e
 
 derive instance functorExcept ∷ Functor (Except e)
 
-type EXCEPT e = FProxy (Except e)
+type EXCEPT :: forall k. Type -> Row (k -> Type) -> Row (k -> Type)
+type EXCEPT e r = (except :: Except e | r)
 
-type FAIL = EXCEPT Unit
+type Fail :: forall k. k -> Type
+type Fail = Except Unit
 
-_except ∷ SProxy "except"
-_except = SProxy
+type FAIL :: forall k. Row (k -> Type) -> Row (k -> Type)
+type FAIL r = EXCEPT Unit r
 
-liftExcept ∷ ∀ e a r. Except e a → Run (except ∷ EXCEPT e | r) a
+_except ∷ Proxy "except"
+_except = Proxy
+
+liftExcept ∷ ∀ e a r. Except e a → Run (EXCEPT e + r) a
 liftExcept = liftExceptAt _except
 
 liftExceptAt
-  ∷ ∀ t e a r s
+  ∷ ∀ proxy t e a r s
   . IsSymbol s
-  ⇒ Row.Cons s (EXCEPT e) t r
-  ⇒ SProxy s
+  ⇒ Row.Cons s (Except e) t r
+  ⇒ proxy s
   → Except e a
   → Run r a
 liftExceptAt = Run.lift
 
-throw ∷ ∀ e a r. e → Run (except ∷ EXCEPT e | r) a
+throw ∷ ∀ e a r. e → Run (EXCEPT e + r) a
 throw = throwAt _except
 
 throwAt
-  ∷ ∀ t e a r s
+  ∷ ∀ proxy t e a r s
   . IsSymbol s
-  ⇒ Row.Cons s (EXCEPT e) t r
-  ⇒ SProxy s
+  ⇒ Row.Cons s (Except e) t r
+  ⇒ proxy s
   → e
   → Run r a
 throwAt sym = liftExceptAt sym <<< Except
 
-fail ∷ ∀ a r. Run (except ∷ FAIL | r) a
+fail ∷ ∀ a r. Run (FAIL + r) a
 fail = failAt _except
 
 failAt ∷
-  ∀ t a r s
+  ∀ proxy t a r s
   . IsSymbol s
-  ⇒ Row.Cons s FAIL t r
-  ⇒ SProxy s
+  ⇒ Row.Cons s Fail t r
+  ⇒ proxy s
   → Run r a
 failAt sym = throwAt sym unit
 
-rethrow ∷ ∀ e a r. Either e a → Run (except ∷ EXCEPT e | r) a
+rethrow ∷ ∀ e a r. Either e a → Run (EXCEPT e + r) a
 rethrow = rethrowAt _except
 
 rethrowAt ∷
-  ∀ t e a r s
+  ∀ proxy t e a r s
   . IsSymbol s
-  ⇒ Row.Cons s (EXCEPT e) t r
-  ⇒ SProxy s
+  ⇒ Row.Cons s (Except e) t r
+  ⇒ proxy s
   → Either e a
   → Run r a
 rethrowAt sym = either (throwAt sym) pure
 
-note ∷ ∀ e a r. e → Maybe a → Run (except ∷ EXCEPT e | r) a
+note ∷ ∀ e a r. e → Maybe a → Run (EXCEPT e + r) a
 note = noteAt _except
 
 noteAt ∷
-  ∀ t e a r s
+  ∀ proxy t e a r s
   . IsSymbol s
-  ⇒ Row.Cons s (EXCEPT e) t r
-  ⇒ SProxy s
+  ⇒ Row.Cons s (Except e) t r
+  ⇒ proxy s
   → e
   → Maybe a
   → Run r a
 noteAt sym e = maybe' (\_ → throwAt sym e) pure
 
-fromJust ∷ ∀ a r. Maybe a → Run (except ∷ FAIL | r) a
+fromJust ∷ ∀ a r. Maybe a → Run (FAIL + r) a
 fromJust = fromJustAt _except
 
 fromJustAt ∷
-  ∀ t a r s
+  ∀ proxy t a r s
   . IsSymbol s
-  ⇒ Row.Cons s FAIL t r
-  ⇒ SProxy s
+  ⇒ Row.Cons s Fail t r
+  ⇒ proxy s
   → Maybe a
   → Run r a
 fromJustAt sym = noteAt sym unit
 
-catch ∷ ∀ e a r. (e → Run r a) → Run (except ∷ EXCEPT e | r) a → Run r a
+catch ∷ ∀ e a r. (e → Run r a) → Run (EXCEPT e + r) a → Run r a
 catch = catchAt _except
 
 catchAt ∷
-  ∀ t e a r s
+  ∀ proxy t e a r s
   . IsSymbol s
-  ⇒ Row.Cons s (EXCEPT e) t r
-  ⇒ SProxy s
+  ⇒ Row.Cons s (Except e) t r
+  ⇒ proxy s
   → (e → Run t a)
   → Run r a
   → Run t a
@@ -138,14 +146,14 @@ catchAt sym = loop
     Right a →
       pure a
 
-runExcept ∷ ∀ e a r. Run (except ∷ EXCEPT e | r) a → Run r (Either e a)
+runExcept ∷ ∀ e a r. Run (EXCEPT e + r) a → Run r (Either e a)
 runExcept = runExceptAt _except
 
 runExceptAt ∷
-  ∀ t e a r s
+  ∀ proxy t e a r s
   . IsSymbol s
-  ⇒ Row.Cons s (EXCEPT e) t r
-  ⇒ SProxy s
+  ⇒ Row.Cons s (Except e) t r
+  ⇒ proxy s
   → Run r a
   → Run t (Either e a)
 runExceptAt sym = loop
@@ -160,14 +168,14 @@ runExceptAt sym = loop
     Right a →
       pure (Right a)
 
-runFail ∷ ∀ a r. Run (except ∷ FAIL | r) a → Run r (Maybe a)
+runFail ∷ ∀ a r. Run (FAIL + r) a → Run r (Maybe a)
 runFail = runFailAt _except
 
 runFailAt ∷
-  ∀ t a r s
+  ∀ proxy t a r s
   . IsSymbol s
-  ⇒ Row.Cons s FAIL t r
-  ⇒ SProxy s
+  ⇒ Row.Cons s Fail t r
+  ⇒ proxy s
   → Run r a
   → Run t (Maybe a)
 runFailAt sym = map (either (const Nothing) Just) <<< runExceptAt sym

--- a/src/Run/Except.purs
+++ b/src/Run/Except.purs
@@ -37,7 +37,7 @@ import Type.Row (type (+))
 newtype Except :: forall k. Type -> k -> Type
 newtype Except e a = Except e
 
-derive instance functorExcept ∷ Functor (Except e)
+derive instance functorExcept :: Functor (Except e)
 
 type EXCEPT :: forall k. Type -> Row (k -> Type) -> Row (k -> Type)
 type EXCEPT e r = (except :: Except e | r)
@@ -48,134 +48,134 @@ type Fail = Except Unit
 type FAIL :: forall k. Row (k -> Type) -> Row (k -> Type)
 type FAIL r = EXCEPT Unit r
 
-_except ∷ Proxy "except"
+_except :: Proxy "except"
 _except = Proxy
 
-liftExcept ∷ ∀ e a r. Except e a → Run (EXCEPT e + r) a
+liftExcept :: forall e a r. Except e a -> Run (EXCEPT e + r) a
 liftExcept = liftExceptAt _except
 
 liftExceptAt
-  ∷ ∀ proxy t e a r s
+  :: forall proxy t e a r s
   . IsSymbol s
-  ⇒ Row.Cons s (Except e) t r
-  ⇒ proxy s
-  → Except e a
-  → Run r a
+  => Row.Cons s (Except e) t r
+  => proxy s
+  -> Except e a
+  -> Run r a
 liftExceptAt = Run.lift
 
-throw ∷ ∀ e a r. e → Run (EXCEPT e + r) a
+throw :: forall e a r. e -> Run (EXCEPT e + r) a
 throw = throwAt _except
 
 throwAt
-  ∷ ∀ proxy t e a r s
+  :: forall proxy t e a r s
   . IsSymbol s
-  ⇒ Row.Cons s (Except e) t r
-  ⇒ proxy s
-  → e
-  → Run r a
+  => Row.Cons s (Except e) t r
+  => proxy s
+  -> e
+  -> Run r a
 throwAt sym = liftExceptAt sym <<< Except
 
-fail ∷ ∀ a r. Run (FAIL + r) a
+fail :: forall a r. Run (FAIL + r) a
 fail = failAt _except
 
-failAt ∷
-  ∀ proxy t a r s
+failAt ::
+  forall proxy t a r s
   . IsSymbol s
-  ⇒ Row.Cons s Fail t r
-  ⇒ proxy s
-  → Run r a
+  => Row.Cons s Fail t r
+  => proxy s
+  -> Run r a
 failAt sym = throwAt sym unit
 
-rethrow ∷ ∀ e a r. Either e a → Run (EXCEPT e + r) a
+rethrow :: forall e a r. Either e a -> Run (EXCEPT e + r) a
 rethrow = rethrowAt _except
 
-rethrowAt ∷
-  ∀ proxy t e a r s
+rethrowAt ::
+  forall proxy t e a r s
   . IsSymbol s
-  ⇒ Row.Cons s (Except e) t r
-  ⇒ proxy s
-  → Either e a
-  → Run r a
+  => Row.Cons s (Except e) t r
+  => proxy s
+  -> Either e a
+  -> Run r a
 rethrowAt sym = either (throwAt sym) pure
 
-note ∷ ∀ e a r. e → Maybe a → Run (EXCEPT e + r) a
+note :: forall e a r. e -> Maybe a -> Run (EXCEPT e + r) a
 note = noteAt _except
 
-noteAt ∷
-  ∀ proxy t e a r s
+noteAt ::
+  forall proxy t e a r s
   . IsSymbol s
-  ⇒ Row.Cons s (Except e) t r
-  ⇒ proxy s
-  → e
-  → Maybe a
-  → Run r a
-noteAt sym e = maybe' (\_ → throwAt sym e) pure
+  => Row.Cons s (Except e) t r
+  => proxy s
+  -> e
+  -> Maybe a
+  -> Run r a
+noteAt sym e = maybe' (\_ -> throwAt sym e) pure
 
-fromJust ∷ ∀ a r. Maybe a → Run (FAIL + r) a
+fromJust :: forall a r. Maybe a -> Run (FAIL + r) a
 fromJust = fromJustAt _except
 
-fromJustAt ∷
-  ∀ proxy t a r s
+fromJustAt ::
+  forall proxy t a r s
   . IsSymbol s
-  ⇒ Row.Cons s Fail t r
-  ⇒ proxy s
-  → Maybe a
-  → Run r a
+  => Row.Cons s Fail t r
+  => proxy s
+  -> Maybe a
+  -> Run r a
 fromJustAt sym = noteAt sym unit
 
-catch ∷ ∀ e a r. (e → Run r a) → Run (EXCEPT e + r) a → Run r a
+catch :: forall e a r. (e -> Run r a) -> Run (EXCEPT e + r) a -> Run r a
 catch = catchAt _except
 
-catchAt ∷
-  ∀ proxy t e a r s
+catchAt ::
+  forall proxy t e a r s
   . IsSymbol s
-  ⇒ Row.Cons s (Except e) t r
-  ⇒ proxy s
-  → (e → Run t a)
-  → Run r a
-  → Run t a
+  => Row.Cons s (Except e) t r
+  => proxy s
+  -> (e -> Run t a)
+  -> Run r a
+  -> Run t a
 catchAt sym = loop
   where
   handle = Run.on sym Left Right
   loop k r = case Run.peel r of
-    Left a → case handle a of
-      Left (Except e) →
+    Left a -> case handle a of
+      Left (Except e) ->
         k e
-      Right a' →
+      Right a' ->
         Run.send a' >>= loop k
-    Right a →
+    Right a ->
       pure a
 
-runExcept ∷ ∀ e a r. Run (EXCEPT e + r) a → Run r (Either e a)
+runExcept :: forall e a r. Run (EXCEPT e + r) a -> Run r (Either e a)
 runExcept = runExceptAt _except
 
-runExceptAt ∷
-  ∀ proxy t e a r s
+runExceptAt ::
+  forall proxy t e a r s
   . IsSymbol s
-  ⇒ Row.Cons s (Except e) t r
-  ⇒ proxy s
-  → Run r a
-  → Run t (Either e a)
+  => Row.Cons s (Except e) t r
+  => proxy s
+  -> Run r a
+  -> Run t (Either e a)
 runExceptAt sym = loop
   where
   handle = Run.on sym Left Right
   loop r = case Run.peel r of
-    Left a → case handle a of
-      Left (Except e) →
+    Left a -> case handle a of
+      Left (Except e) ->
         pure (Left e)
-      Right a' →
+      Right a' ->
         Run.send a' >>= loop
-    Right a →
+    Right a ->
       pure (Right a)
 
-runFail ∷ ∀ a r. Run (FAIL + r) a → Run r (Maybe a)
+runFail :: forall a r. Run (FAIL + r) a -> Run r (Maybe a)
 runFail = runFailAt _except
 
-runFailAt ∷
-  ∀ proxy t a r s
+runFailAt ::
+  forall proxy t a r s
   . IsSymbol s
-  ⇒ Row.Cons s Fail t r
-  ⇒ proxy s
-  → Run r a
-  → Run t (Maybe a)
+  => Row.Cons s Fail t r
+  => proxy s
+  -> Run r a
+  -> Run t (Maybe a)
 runFailAt sym = map (either (const Nothing) Just) <<< runExceptAt sym

--- a/src/Run/Internal.purs
+++ b/src/Run/Internal.purs
@@ -14,25 +14,25 @@ import Unsafe.Coerce (unsafeCoerce)
 
 data Choose a
   = Empty
-  | Alt (Boolean → a)
+  | Alt (Boolean -> a)
 
-derive instance functorChoose ∷ Functor Choose
+derive instance functorChoose :: Functor Choose
 
 type CHOOSE r = ( choose :: Choose | r )
 
-_choose ∷ Proxy "choose"
+_choose :: Proxy "choose"
 _choose = Proxy
 
 toRows
-  ∷ ∀ f r1 r2 a
+  :: forall f r1 r2 a
   . TypeEquals (Proxy r1) (Proxy r2)
-  ⇒ f r1 a
-  → f r2 a
+  => f r1 a
+  -> f r2 a
 toRows = unsafeCoerce
 
 fromRows
-  ∷ ∀ f r1 r2 a
+  :: forall f r1 r2 a
   . TypeEquals (Proxy r1) (Proxy r2)
-  ⇒ f r2 a
-  → f r1 a
+  => f r2 a
+  -> f r1 a
 fromRows = unsafeCoerce

--- a/src/Run/Internal.purs
+++ b/src/Run/Internal.purs
@@ -8,9 +8,8 @@ module Run.Internal
 
 import Prelude
 
-import Data.Functor.Variant (FProxy, SProxy(..))
-import Type.Data.Row (RProxy)
 import Type.Equality (class TypeEquals)
+import Type.Proxy (Proxy(..))
 import Unsafe.Coerce (unsafeCoerce)
 
 data Choose a
@@ -19,21 +18,21 @@ data Choose a
 
 derive instance functorChoose ∷ Functor Choose
 
-type CHOOSE = FProxy Choose
+type CHOOSE r = ( choose :: Choose | r )
 
-_choose ∷ SProxy "choose"
-_choose = SProxy
+_choose ∷ Proxy "choose"
+_choose = Proxy
 
 toRows
   ∷ ∀ f r1 r2 a
-  . TypeEquals (RProxy r1) (RProxy r2)
+  . TypeEquals (Proxy r1) (Proxy r2)
   ⇒ f r1 a
   → f r2 a
 toRows = unsafeCoerce
 
 fromRows
   ∷ ∀ f r1 r2 a
-  . TypeEquals (RProxy r1) (RProxy r2)
+  . TypeEquals (Proxy r1) (Proxy r2)
   ⇒ f r2 a
   → f r1 a
 fromRows = unsafeCoerce

--- a/src/Run/Reader.purs
+++ b/src/Run/Reader.purs
@@ -24,94 +24,94 @@ import Run as Run
 import Type.Proxy (Proxy(..))
 import Type.Row (type (+))
 
-newtype Reader e a = Reader (e → a)
+newtype Reader e a = Reader (e -> a)
 
-derive newtype instance functorReader ∷ Functor (Reader e)
+derive newtype instance functorReader :: Functor (Reader e)
 
 type READER e r = (reader :: Reader e | r)
 
-_reader ∷ Proxy "reader"
+_reader :: Proxy "reader"
 _reader = Proxy
 
-liftReader ∷ ∀ e a r. Reader e a → Run (READER e + r) a
+liftReader :: forall e a r. Reader e a -> Run (READER e + r) a
 liftReader = liftReaderAt _reader
 
-liftReaderAt ∷
-  ∀ proxy t e a r s
+liftReaderAt ::
+  forall proxy t e a r s
   . IsSymbol s
-  ⇒ Row.Cons s (Reader e) t r
-  ⇒ proxy s
-  → Reader e a
-  → Run r a
+  => Row.Cons s (Reader e) t r
+  => proxy s
+  -> Reader e a
+  -> Run r a
 liftReaderAt = Run.lift
 
-ask ∷ ∀ e r. Run (READER e + r) e
+ask :: forall e r. Run (READER e + r) e
 ask = askAt _reader
 
-askAt ∷
-  ∀ proxy t e r s
+askAt ::
+  forall proxy t e r s
   . IsSymbol s
-  ⇒ Row.Cons s (Reader e) t r
-  ⇒ proxy s
-  → Run r e
+  => Row.Cons s (Reader e) t r
+  => proxy s
+  -> Run r e
 askAt sym = asksAt sym identity
 
-asks ∷ ∀ e r a. (e → a) → Run (READER e + r) a
+asks :: forall e r a. (e -> a) -> Run (READER e + r) a
 asks = asksAt _reader
 
-asksAt ∷
-  ∀ proxy t e r s a
+asksAt ::
+  forall proxy t e r s a
   . IsSymbol s
-  ⇒ Row.Cons s (Reader e) t r
-  ⇒ proxy s
-  → (e → a)
-  → Run r a
+  => Row.Cons s (Reader e) t r
+  => proxy s
+  -> (e -> a)
+  -> Run r a
 asksAt sym f = liftReaderAt sym (Reader f)
 
-local ∷ ∀ e a r. (e → e) → Run (READER e + r) a → Run (READER e + r) a
+local :: forall e a r. (e -> e) -> Run (READER e + r) a -> Run (READER e + r) a
 local = localAt _reader
 
-localAt ∷
-  ∀ proxy t e a r s
+localAt ::
+  forall proxy t e a r s
   . IsSymbol s
-  ⇒ Row.Cons s (Reader e) t r
-  ⇒ proxy s
-  → (e → e)
-  → Run r a
-  → Run r a
-localAt sym = \f r → map f (askAt sym) >>= flip runLocal r
+  => Row.Cons s (Reader e) t r
+  => proxy s
+  -> (e -> e)
+  -> Run r a
+  -> Run r a
+localAt sym = \f r -> map f (askAt sym) >>= flip runLocal r
   where
   handle = Run.on sym Left Right
   runLocal = loop
     where
     loop e r = case Run.peel r of
-      Left a → case handle a of
-        Left (Reader k) →
+      Left a -> case handle a of
+        Left (Reader k) ->
           loop e (k e)
-        Right _ →
+        Right _ ->
           Run.send a >>= runLocal e
-      Right a →
+      Right a ->
         pure a
 
-runReader ∷ ∀ e a r. e → Run (READER e + r) a → Run r a
+runReader :: forall e a r. e -> Run (READER e + r) a -> Run r a
 runReader = runReaderAt _reader
 
-runReaderAt ∷
-  ∀ proxy t e a r s
+runReaderAt ::
+  forall proxy t e a r s
   . IsSymbol s
-  ⇒ Row.Cons s (Reader e) t r
-  ⇒ proxy s
-  → e
-  → Run r a
-  → Run t a
+  => Row.Cons s (Reader e) t r
+  => proxy s
+  -> e
+  -> Run r a
+  -> Run t a
 runReaderAt sym = loop
   where
   handle = Run.on sym Left Right
   loop e r = case Run.peel r of
-    Left a → case handle a of
-      Left (Reader k) →
+    Left a -> case handle a of
+      Left (Reader k) ->
         loop e (k e)
-      Right a' →
+      Right a' ->
         Run.send a' >>= runReaderAt sym e
-    Right a →
+    Right a ->
       pure a

--- a/src/Run/State.purs
+++ b/src/Run/State.purs
@@ -26,85 +26,87 @@ import Data.Either (Either(..))
 import Data.Symbol (class IsSymbol)
 import Data.Tuple (Tuple(..), fst, snd)
 import Prim.Row as Row
-import Run (Run, SProxy(..), FProxy)
+import Run (Run)
 import Run as Run
+import Type.Proxy (Proxy(..))
+import Type.Row (type (+))
 
 data State s a = State (s → s) (s → a)
 
 derive instance functorState ∷ Functor (State s)
 
-type STATE s = FProxy (State s)
+type STATE s r = (state :: State s | r)
 
-_state ∷ SProxy "state"
-_state = SProxy
+_state ∷ Proxy "state"
+_state = Proxy
 
-liftState ∷ ∀ s a r. State s a → Run (state ∷ STATE s | r) a
+liftState ∷ ∀ s a r. State s a → Run (STATE s + r) a
 liftState = liftStateAt _state
 
 liftStateAt ∷
-  ∀ q sym s a r
+  ∀ proxy q sym s a r
   . IsSymbol sym
-  ⇒ Row.Cons sym (STATE s) q r
-  ⇒ SProxy sym
+  ⇒ Row.Cons sym (State s) q r
+  ⇒ proxy sym
   → State s a
   → Run r a
 liftStateAt = Run.lift
 
-modify ∷ ∀ s r. (s → s) → Run (state ∷ STATE s | r) Unit
+modify ∷ ∀ s r. (s → s) → Run (STATE s + r) Unit
 modify = modifyAt _state
 
 modifyAt ∷
-  ∀ q sym s r
+  ∀ proxy q sym s r
   . IsSymbol sym
-  ⇒ Row.Cons sym (STATE s) q r
-  ⇒ SProxy sym
+  ⇒ Row.Cons sym (State s) q r
+  ⇒ proxy sym
   → (s → s)
   → Run r Unit
 modifyAt sym f = liftStateAt sym $ State f (const unit)
 
-put ∷ ∀ s r. s → Run (state ∷ STATE s | r) Unit
+put ∷ ∀ s r. s → Run (STATE s + r) Unit
 put = putAt _state
 
 putAt ∷
-  ∀ q sym s r
+  ∀ proxy q sym s r
   . IsSymbol sym
-  ⇒ Row.Cons sym (STATE s) q r
-  ⇒ SProxy sym
+  ⇒ Row.Cons sym (State s) q r
+  ⇒ proxy sym
   → s
   → Run r Unit
 putAt sym = modifyAt sym <<< const
 
-get ∷ ∀ s r. Run (state ∷ STATE s | r) s
+get ∷ ∀ s r. Run (STATE s + r) s
 get = getAt _state
 
 getAt ∷
-  ∀ q sym s r
+  ∀ proxy q sym s r
   . IsSymbol sym
-  ⇒ Row.Cons sym (STATE s) q r
-  ⇒ SProxy sym
+  ⇒ Row.Cons sym (State s) q r
+  ⇒ proxy sym
   → Run r s
 getAt sym = liftStateAt sym $ State identity identity
 
-gets ∷ ∀ s t r. (s → t) → Run (state ∷ STATE s | r) t
+gets ∷ ∀ s t r. (s → t) → Run (STATE s + r) t
 gets = getsAt _state
 
 getsAt ∷
-  ∀ q sym s t r
+  ∀ proxy q sym s t r
   . IsSymbol sym
-  ⇒ Row.Cons sym (STATE s) q r
-  ⇒ SProxy sym
+  ⇒ Row.Cons sym (State s) q r
+  ⇒ proxy sym
   → (s → t)
   → Run r t
 getsAt sym = flip map (getAt sym)
 
-runState ∷ ∀ s r a. s → Run (state ∷ STATE s | r) a → Run r (Tuple s a)
+runState ∷ ∀ s r a. s → Run (STATE s + r) a → Run r (Tuple s a)
 runState = runStateAt _state
 
 runStateAt ∷
-  ∀ q sym s r a
+  ∀ proxy q sym s r a
   . IsSymbol sym
-  ⇒ Row.Cons sym (STATE s) q r
-  ⇒ SProxy sym
+  ⇒ Row.Cons sym (State s) q r
+  ⇒ proxy sym
   → s
   → Run r a
   → Run q (Tuple s a)
@@ -121,27 +123,27 @@ runStateAt sym = loop
     Right a →
       pure (Tuple s a)
 
-evalState ∷ ∀ s r a. s → Run (state ∷ STATE s | r) a → Run r a
+evalState ∷ ∀ s r a. s → Run (STATE s + r) a → Run r a
 evalState = evalStateAt _state
 
 evalStateAt ∷
-  ∀ q sym s r a
+  ∀ proxy q sym s r a
   . IsSymbol sym
-  ⇒ Row.Cons sym (STATE s) q r
-  ⇒ SProxy sym
+  ⇒ Row.Cons sym (State s) q r
+  ⇒ proxy sym
   → s
   → Run r a
   → Run q a
 evalStateAt sym s = map snd <<< runStateAt sym s
 
-execState ∷ ∀ s r a. s → Run (state ∷ STATE s | r) a → Run r s
+execState ∷ ∀ s r a. s → Run (STATE s + r) a → Run r s
 execState = execStateAt _state
 
 execStateAt ∷
-  ∀ q sym s r a
+  ∀ proxy q sym s r a
   . IsSymbol sym
-  ⇒ Row.Cons sym (STATE s) q r
-  ⇒ SProxy sym
+  ⇒ Row.Cons sym (State s) q r
+  ⇒ proxy sym
   → s
   → Run r a
   → Run q s

--- a/src/Run/Writer.purs
+++ b/src/Run/Writer.purs
@@ -27,94 +27,94 @@ import Type.Row (type (+))
 
 data Writer w a = Writer w a
 
-derive instance functorWriter ∷ Functor (Writer w)
+derive instance functorWriter :: Functor (Writer w)
 
-type WRITER w r = (writer ∷ Writer w | r)
+type WRITER w r = (writer :: Writer w | r)
 
-_writer ∷ Proxy "writer"
+_writer :: Proxy "writer"
 _writer = Proxy
 
-liftWriter ∷ ∀ w a r. Writer w a → Run (WRITER w + r) a
+liftWriter :: forall w a r. Writer w a -> Run (WRITER w + r) a
 liftWriter = liftWriterAt _writer
 
-liftWriterAt ∷
-  ∀ proxy w a r t s
+liftWriterAt ::
+  forall proxy w a r t s
   . IsSymbol s
-  ⇒ Row.Cons s (Writer w) t r
-  ⇒ proxy s
-  → Writer w a
-  → Run r a
+  => Row.Cons s (Writer w) t r
+  => proxy s
+  -> Writer w a
+  -> Run r a
 liftWriterAt = Run.lift
 
-tell ∷ ∀ w r. w → Run (writer ∷ Writer w | r) Unit
+tell :: forall w r. w -> Run (writer :: Writer w | r) Unit
 tell = tellAt _writer
 
-tellAt ∷
-  ∀ proxy w r t s
+tellAt ::
+  forall proxy w r t s
   . IsSymbol s
-  ⇒ Row.Cons s (Writer w) t r
-  ⇒ proxy s
-  → w
-  → Run r Unit
+  => Row.Cons s (Writer w) t r
+  => proxy s
+  -> w
+  -> Run r Unit
 tellAt sym w = liftWriterAt sym (Writer w unit)
 
-censor ∷ ∀ w a r. (w → w) → Run (writer ∷ Writer w | r) a → Run (writer ∷ Writer w | r) a
+censor :: forall w a r. (w -> w) -> Run (writer :: Writer w | r) a -> Run (writer :: Writer w | r) a
 censor = censorAt _writer
 
-censorAt ∷
-  ∀ proxy w a r t s
+censorAt ::
+  forall proxy w a r t s
   . IsSymbol s
-  ⇒ Row.Cons s (Writer w) t r
-  ⇒ proxy s
-  → (w → w)
-  → Run r a
-  → Run r a
+  => Row.Cons s (Writer w) t r
+  => proxy s
+  -> (w -> w)
+  -> Run r a
+  -> Run r a
 censorAt sym = loop
   where
   handle = Run.on sym Left Right
   loop f r = case Run.peel r of
-    Left a → case handle a of
-      Left (Writer w n) → do
+    Left a -> case handle a of
+      Left (Writer w n) -> do
         tellAt sym (f w)
         loop f n
-      Right _ →
+      Right _ ->
         Run.send a >>= loop f
-    Right a →
+    Right a ->
       pure a
 
-foldWriter ∷ ∀ w b a r. (b → w → b) → b → Run (WRITER w + r) a → Run r (Tuple b a)
+foldWriter :: forall w b a r. (b -> w -> b) -> b -> Run (WRITER w + r) a -> Run r (Tuple b a)
 foldWriter = foldWriterAt _writer
 
-foldWriterAt ∷
-  ∀ proxy w b a r t s
+foldWriterAt ::
+  forall proxy w b a r t s
   . IsSymbol s
-  ⇒ Row.Cons s (Writer w) t r
-  ⇒ proxy s
-  → (b → w → b)
-  → b
-  → Run r a
-  → Run t (Tuple b a)
+  => Row.Cons s (Writer w) t r
+  => proxy s
+  -> (b -> w -> b)
+  -> b
+  -> Run r a
+  -> Run t (Tuple b a)
 foldWriterAt sym = loop
   where
   handle = Run.on sym Left Right
   loop k w r = case Run.peel r of
-    Left a → case handle a of
-      Left (Writer w' n) →
+    Left a -> case handle a of
+      Left (Writer w' n) ->
         loop k (k w w') n
-      Right a' →
+      Right a' ->
         Run.send a' >>= foldWriterAt sym k w
-    Right a →
+    Right a ->
       pure (Tuple w a)
 
-runWriter ∷ ∀ w a r. Monoid w ⇒ Run (WRITER w + r) a → Run r (Tuple w a)
+runWriter :: forall w a r. Monoid w => Run (WRITER w + r) a -> Run r (Tuple w a)
 runWriter = runWriterAt _writer
 
-runWriterAt ∷
-  ∀ proxy w a r t s
+runWriterAt ::
+  forall proxy w a r t s
   . IsSymbol s
-  ⇒ Monoid w
-  ⇒ Row.Cons s (Writer w) t r
-  ⇒ proxy s
-  → Run r a
-  → Run t (Tuple w a)
+  => Monoid w
+  => Row.Cons s (Writer w) t r
+  => proxy s
+  -> Run r a
+  -> Run t (Tuple w a)
 runWriterAt sym = foldWriterAt sym (<>) mempty


### PR DESCRIPTION
This PR updates for PureScript 0.14. Namely:

- Updates dependencies in Bower by bumping a major version
- Updates the repository URL in Bower for compatibility with the PureScript registry
- Updates the source code and tests for compatibility with the new `variant` and with PureScript 0.14

I also replaced unicode symbols with their ascii equivalents, as neither of us use unicode otherwise. I've verified everything builds and passes the tests. 

The other major change here is switching all the type synonyms using `FProxy` to be open rows instead so they can be combined with `Type.Row.+` -- `FProxy` is no longer needed due to polykinds. For example:

```diff
- type AFF = FProxy Aff
+ type AFF r = (aff :: Aff | r)
```